### PR TITLE
Whitelist related envs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 kafka-lagcheck
 kafka-lagcheck.exe
+*.iml
+vendor/*/

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,9 +18,8 @@ RUN apk add --no-cache --virtual .build-dependencies git \
   && BUILDER="builder=$(go version)" \
   && LDFLAGS="-X '"${BUILDINFO_PACKAGE}$VERSION"' -X '"${BUILDINFO_PACKAGE}$DATETIME"' -X '"${BUILDINFO_PACKAGE}$REPOSITORY"' -X '"${BUILDINFO_PACKAGE}$REVISION"' -X '"${BUILDINFO_PACKAGE}$BUILDER"'" \
   && echo "Fetching dependencies..." \
-  && go get -d -t -v \
-  && echo "Running tests..." \
-  && go test \
+  && go get -u github.com/kardianos/govendor \
+  && $GOPATH/bin/govendor sync \
   && echo "Building app..." \
   && echo "Build flags: $LDFLAGS" \
   && CGO_ENABLED=0 go build -a -installsuffix cgo -ldflags="${LDFLAGS}" -o /${PROJECT} ${REPO_PATH} \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,32 @@
-FROM alpine:3.4
+FROM golang:1.7-alpine3.5
 
-ADD *.go /kafka-lagcheck/
+ENV PROJECT=kafka-lagcheck
+COPY . /${PROJECT}-sources/
 
-RUN apk update \
-  && apk add bash \
-  && apk add git bzr \
-  && apk add go \
-  && export GOPATH=/gopath \
-  && export LAGCHECK_REPO_PATH="github.com/Financial-Times/kafka-lagcheck" \
-  && mkdir -p $GOPATH/src/${LAGCHECK_REPO_PATH} \
-  && cp -r /kafka-lagcheck/*.go $GOPATH/src/${LAGCHECK_REPO_PATH}/ \
-  && cd $GOPATH/src/${LAGCHECK_REPO_PATH} \
-  && go get -t ./... \
-  && go build \
-  && mv kafka-lagcheck /kafka-lagcheck-app \
-  && rm -rf /kafka-lagcheck \
-  && mv /kafka-lagcheck-app /kafka-lagcheck \
-  && apk del go git bzr \
-  && rm -rf $GOPATH /var/cache/apk/*
+RUN apk add --no-cache --virtual .build-dependencies git \
+  && ORG_PATH="github.com/Financial-Times" \
+  && REPO_PATH="${ORG_PATH}/${PROJECT}" \
+  && mkdir -p $GOPATH/src/${ORG_PATH} \
+# Linking the project sources in the GOPATH folder
+  && ln -s /${PROJECT}-sources $GOPATH/src/${REPO_PATH} \
+  && cd $GOPATH/src/${REPO_PATH} \
+  && BUILDINFO_PACKAGE="github.com/Financial-Times/service-status-go/buildinfo." \
+  && VERSION="version=$(git describe --tag --always 2> /dev/null)" \
+  && DATETIME="dateTime=$(date -u +%Y%m%d%H%M%S)" \
+  && REPOSITORY="repository=$(git config --get remote.origin.url)" \
+  && REVISION="revision=$(git rev-parse HEAD)" \
+  && BUILDER="builder=$(go version)" \
+  && LDFLAGS="-X '"${BUILDINFO_PACKAGE}$VERSION"' -X '"${BUILDINFO_PACKAGE}$DATETIME"' -X '"${BUILDINFO_PACKAGE}$REPOSITORY"' -X '"${BUILDINFO_PACKAGE}$REVISION"' -X '"${BUILDINFO_PACKAGE}$BUILDER"'" \
+  && echo "Fetching dependencies..." \
+  && go get -d -t -v \
+  && echo "Running tests..." \
+  && go test \
+  && echo "Building app..." \
+  && echo "Build flags: $LDFLAGS" \
+  && CGO_ENABLED=0 go build -a -installsuffix cgo -ldflags="${LDFLAGS}" -o /${PROJECT} ${REPO_PATH} \
+  && apk del .build-dependencies \
+  && rm -rf $GOPATH/src $GOPATH/pkg $GOPATH/.cache $GOPATH/bin /${PROJECT}-sources
 
-CMD [ "/kafka-lagcheck" ]
+WORKDIR /
+# Using the expanded command, so that the shell will expand the $PROJECT env var. See https://docs.docker.com/engine/reference/builder/#cmd
+CMD ["/kafka-lagcheck"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.8-alpine3.5
+FROM golang:1.8-alpine
 
 ENV PROJECT=kafka-lagcheck
 COPY . /${PROJECT}-sources/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.7-alpine3.5
+FROM golang:1.8-alpine3.5
 
 ENV PROJECT=kafka-lagcheck
 COPY . /${PROJECT}-sources/

--- a/README.md
+++ b/README.md
@@ -3,17 +3,31 @@
 [![CircleCI](https://circleci.com/gh/Financial-Times/kafka-lagcheck.svg?style=shield)](https://circleci.com/gh/Financial-Times/kafka-lagcheck) [![Coverage Status](https://coveralls.io/repos/github/Financial-Times/kafka-lagcheck/badge.svg)](https://coveralls.io/github/Financial-Times/kafka-lagcheck)
 
 Just creates a healthcheck and good-to-go endpoint that's checking kafka consumer lags.
-
 Connects to an application based on [github.com/linkedin/Burrow](https://github.com/linkedin/Burrow)
+The go app is only serving as a forwarder, it makes requests to Burrow, and forms the result in an FT standard healthcheck format. e.g.
 
-## Run locally
+## Installation
 
 1. You need to set up a [burrow](https://github.com/Financial-Times/burrow) running locally.
 2. `go get github.com/Financial-Times/kafka-lagcheck`
 3. `cd $GOPATH/src/github.com/Financial-Times/kafka-lagcheck`
-4. `go install`
-5. `./kafka-lagcheck`
+4. `go get -u github.com/kardianos/govendor `
+5. `$GOPATH/bin/govendor sync `
+6. `go install`
+ 
+## Run locally
+ To run the app, first install it, then run the following command:
+ `./kafka-lagcheck`
+## Service endpoints
+### Health endpoint:
+For each consumer, check if it lags behind.
+- Using curl: `curl localhost:8080/__health`
+### GTG endpoint
+- Using curl: `curl localhost:8080/__gtg`
 
-The go app is only serving as a forwarder, it makes requests to Burrow, and forms the result in an FT standard healthcheck format. e.g.
-
-`curl localhost:8080/__health`
+## Other information
+### Whitelisting environments
+To filter out the list of consumers that are checked for lag, a whitelist of environments can be specified, consequently 
+the app will monitor only consumers from the current cluster and Kafka Bridges that are located in environments that belong
+to the whitelist.
+The environments whitelist should be stored in the environment variable with name `WHITELISTED_ENVS`

--- a/README.md
+++ b/README.md
@@ -30,4 +30,7 @@ For each consumer, check if it lags behind.
 To filter out the list of consumers that are checked for lag, a whitelist of environments can be specified, consequently 
 the app will monitor only consumers from the current cluster and Kafka Bridges that are located in environments that belong
 to the whitelist.
+
 The environments whitelist should be stored in the environment variable with name `WHITELISTED_ENVS`
+As an example, if the kafka-lagcheck from `pub-prod-env1` environment has WHITELISTED_ENVS = `prod-env1, prod-env2`, then only consumers from `pub-prod-env1` and kafka bridges from `prod-env1` and `prod-env2` will appear 
+in the healthchecks list, while kafka-bridges from other environments (e.g. `pre-prod`) will be ignored.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # kafka-lagcheck - Kafka Consumer Lag Checking
 
-Just creates a healthcheck and good-to-go endpoint that's checking kafka consumer lags..
+[![CircleCI](https://circleci.com/gh/Financial-Times/kafka-lagcheck.svg?style=shield)](https://circleci.com/gh/Financial-Times/kafka-lagcheck) [![Coverage Status](https://coveralls.io/repos/github/Financial-Times/kafka-lagcheck/badge.svg)](https://coveralls.io/github/Financial-Times/kafka-lagcheck)
+
+Just creates a healthcheck and good-to-go endpoint that's checking kafka consumer lags.
 
 Connects to an application based on [github.com/linkedin/Burrow](https://github.com/linkedin/Burrow)
 

--- a/circle.yml
+++ b/circle.yml
@@ -3,7 +3,7 @@ machine:
     PROJECT_GOPATH: "${HOME}/.go_project"
     PROJECT_PARENT_PATH: "${PROJECT_GOPATH}/src/github.com/${CIRCLE_PROJECT_USERNAME}"
     PROJECT_PATH: "${PROJECT_PARENT_PATH}/${CIRCLE_PROJECT_REPONAME}"
-    GOPATH: "${HOME}/.go_workspace:/usr/local/go_workspace:${PROJECT_GOPATH}"
+    GOPATH: "${HOME}/.go_workspace:${PROJECT_GOPATH}"
 
 checkout:
   post:

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,30 @@
+machine:
+  environment:
+    PROJECT_GOPATH: "${HOME}/.go_project"
+    PROJECT_PARENT_PATH: "${PROJECT_GOPATH}/src/github.com/${CIRCLE_PROJECT_USERNAME}"
+    PROJECT_PATH: "${PROJECT_PARENT_PATH}/${CIRCLE_PROJECT_REPONAME}"
+    GOPATH: "${HOME}/.go_workspace:/usr/local/go_workspace:${PROJECT_GOPATH}"
+
+checkout:
+  post:
+    - mkdir -p "${PROJECT_PARENT_PATH}"
+    - rsync -avC "${HOME}/${CIRCLE_PROJECT_REPONAME}/" "${PROJECT_PATH}"
+
+dependencies:
+  pre:
+    - go get -u github.com/kardianos/govendor
+  override:
+    - cd $PROJECT_PATH && govendor sync
+    - cd $PROJECT_PATH && go build -v
+
+test:
+  pre:
+    - go get -u github.com/jstemmer/go-junit-report
+    - go get -u github.com/mattn/goveralls
+    - cd $PROJECT_PATH && wget https://raw.githubusercontent.com/Financial-Times/cookiecutter-upp-golang/master/coverage.sh && chmod +x coverage.sh
+  override:
+    - mkdir -p $CIRCLE_TEST_REPORTS/golang
+    - cd $PROJECT_PATH && govendor test -race -v +local | go-junit-report > $CIRCLE_TEST_REPORTS/golang/junit.xml
+    - cd $PROJECT_PATH && ./coverage.sh
+  post:
+    - goveralls -coverprofile=$CIRCLE_ARTIFACTS/coverage.out -service=circle-ci -repotoken=$COVERALLS_TOKEN

--- a/healthcheck.go
+++ b/healthcheck.go
@@ -73,7 +73,9 @@ func (h *healthcheck) consumerLags(consumer string) fthealth.Check {
 		PanicGuide:       "https://sites.google.com/a/ft.com/ft-technology-service-transition/home/run-book-library/kafka-lagcheck",
 		Severity:         1,
 		TechnicalSummary: "Consumer group " + consumer + " is lagging. Further info at: __burrow/v2/kafka/local/consumer/" + consumer + "/status",
-		Checker:          func() error { return h.fetchAndCheckConsumerGroupForLags(consumer) },
+		Checker:          func() error {
+			return h.fetchAndCheckConsumerGroupForLags(consumer)
+		},
 	}
 }
 
@@ -84,7 +86,9 @@ func (h *healthcheck) burrowUnavailableCheck(err error) fthealth.Check {
 		PanicGuide:       "https://sites.google.com/a/ft.com/ft-technology-service-transition/home/run-book-library/kafka-lagcheck",
 		Severity:         1,
 		TechnicalSummary: fmt.Sprintf("Error retrieving consumer group list. Underlying kafka analysis tool burrow@*.service is unavailable. Please restart it or have a look if kafka itself is running properly. %s", err.Error()),
-		Checker:          func() error { return errors.New("Error retrieving consumer group list.") },
+		Checker:          func() error {
+			return errors.New("Error retrieving consumer group list.")
+		},
 	}
 }
 
@@ -95,7 +99,9 @@ func (h *healthcheck) noConsumerGroupsCheck() fthealth.Check {
 		PanicGuide:       "https://sites.google.com/a/ft.com/ft-technology-service-transition/home/run-book-library/kafka-lagcheck",
 		Severity:         1,
 		TechnicalSummary: "Can't see any consumers yet so no lags to report and could successfully connect to kafka. This usually should happen only on startup, please retry in a few moments, and if this case persists, take a more serious look at burrow and kafka.",
-		Checker:          func() error { return nil },
+		Checker:          func() error {
+			return nil
+		},
 	}
 }
 
@@ -222,6 +228,11 @@ func (h *healthcheck) filterOutNonRelatedKafkaBridges(consumers []string) []stri
 }
 
 func (h *healthcheck) isBridgeFromWhitelistedEnvs(bridgeName string) bool {
+	//Do not filter out any Kafke bridge by default
+	if len(h.whitelistedEnvs) == 0 {
+		return true
+	}
+
 	for _, whitelistedEnv := range h.whitelistedEnvs {
 		if strings.HasPrefix(bridgeName, whitelistedEnv) {
 			return true

--- a/healthcheck.go
+++ b/healthcheck.go
@@ -7,9 +7,9 @@ import (
 	"fmt"
 	"github.com/Financial-Times/go-fthealth"
 	"github.com/jmoiron/jsonq"
+	"io"
 	"io/ioutil"
 	"net/http"
-	"io"
 	"strings"
 )
 
@@ -100,7 +100,7 @@ func (h *healthcheck) noConsumerGroupsCheck() fthealth.Check {
 }
 
 func (h *healthcheck) fetchAndCheckConsumerGroupForLags(consumerGroup string) error {
-	resp, err := http.Get(h.checkPrefix+consumerGroup+"/status")
+	resp, err := http.Get(h.checkPrefix + consumerGroup + "/status")
 	if err != nil {
 		warnLogger.Printf("Could not execute request to burrow: %v", err.Error())
 		return err

--- a/healthcheck.go
+++ b/healthcheck.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/Financial-Times/go-fgithealth"
+	"github.com/Financial-Times/go-fthealth"
 	"github.com/jmoiron/jsonq"
 	"io"
 	"io/ioutil"

--- a/healthcheck.go
+++ b/healthcheck.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/Financial-Times/go-fthealth"
+	"github.com/Financial-Times/go-fgithealth"
 	"github.com/jmoiron/jsonq"
 	"io"
 	"io/ioutil"
@@ -144,12 +144,12 @@ func (h *healthcheck) checkConsumerGroupForLags(body []byte, consumerGroup strin
 		return errors.New("Couldn't unmarshall totallag.")
 	}
 	if totalLag > h.lagTolerance {
-		return h.igonreWhitelistedTopics(jq, body, totalLag, consumerGroup)
+		return h.ignoreWhitelistedTopics(jq, body, totalLag, consumerGroup)
 	}
 	return nil
 }
 
-func (h *healthcheck) igonreWhitelistedTopics(jq *jsonq.JsonQuery, body []byte, lag int, consumerGroup string) error {
+func (h *healthcheck) ignoreWhitelistedTopics(jq *jsonq.JsonQuery, body []byte, lag int, consumerGroup string) error {
 	topic1, err1 := jq.String("status", "maxlag", "topic")
 	topic2, err2 := jq.String("status", "partitions", "0", "topic")
 	if err1 != nil && err2 != nil {
@@ -228,7 +228,7 @@ func (h *healthcheck) filterOutNonRelatedKafkaBridges(consumers []string) []stri
 }
 
 func (h *healthcheck) isBridgeFromWhitelistedEnvs(bridgeName string) bool {
-	//Do not filter out any Kafke bridge by default
+	//Do not filter out any Kafka bridge by default
 	if len(h.whitelistedEnvs) == 0 {
 		return true
 	}

--- a/healthcheck_test.go
+++ b/healthcheck_test.go
@@ -281,6 +281,21 @@ func TestConsumerList(t *testing.T) {
 			body: []byte(`{
 				"error": false,
 				"message": "consumer group status returned",
+				"consumers": [
+					"console-consumer-2324",
+					"lower-env1-kafka-bridge-2324",
+					"lower-env2-kafka-bridge-2324",
+					"console-consumer-98135"
+				]
+			}
+			`),
+			err:       nil,
+			consumers: []string{"console-consumer-2324", "lower-env1-kafka-bridge-2324", "console-consumer-98135"},
+		},
+		{
+			body: []byte(`{
+				"error": false,
+				"message": "consumer group status returned",
 				"consumers": []
 			}
 			`),
@@ -289,7 +304,7 @@ func TestConsumerList(t *testing.T) {
 		},
 	}
 	initLogs(ioutil.Discard, ioutil.Discard, ioutil.Discard)
-	h := newHealthcheck("", []string{"Concept"}, []string{}, 30)
+	h := newHealthcheck("", []string{"Concept"}, []string{"lower-env1"}, 30)
 	for _, tc := range testCases {
 		consumers, actualErr := h.parseConsumerGroups(tc.body)
 		actualMsg := "<nil>"
@@ -306,6 +321,41 @@ func TestConsumerList(t *testing.T) {
 		for i, c := range consumers {
 			if c != tc.consumers[i] {
 				t.Errorf("Consumers do not match. Expected: [%s]\nActual: [%s]", tc.consumers, consumers)
+			}
+		}
+	}
+}
+
+func TestFilterOutNonRelatedKafkaBridges(t *testing.T) {
+	var testCases = []struct {
+		whitelistedEnvs []string
+		consumers       []string
+		expected        []string
+	}{
+		{
+			whitelistedEnvs:[]string{},
+			consumers: []string{"console-consumer", "prod-env-kafka-bridge", "lower-env-kafka-bridge"},
+			expected:[]string{"console-consumer", "prod-env-kafka-bridge", "lower-env-kafka-bridge"},
+		},
+		{
+			whitelistedEnvs:[]string{"prod-env"},
+			consumers: []string{"console-consumer", "prod-env-kafka-bridge", "lower-env-kafka-bridge"},
+			expected:[]string{"console-consumer", "prod-env-kafka-bridge"},
+		},
+		{
+			whitelistedEnvs:[]string{"prod-env", "pub-prod-env"},
+			consumers: []string{"console-consumer", "praod-env-kafka-bridge", "lower-env-kafka-bridge", "pre-prod-env-kafka-bridge", "pub-prod-env-kafka-bridge"},
+			expected:[]string{"console-consumer", "prod-env-kafka-bridge", "pub-prod-env-kafka-bridge"},
+		},
+
+	}
+
+	for _, tc := range testCases {
+		h := newHealthcheck("", []string{""}, tc.whitelistedEnvs, 30)
+		filteredConsumers := h.filterOutNonRelatedKafkaBridges(tc.consumers)
+		for i, c := range filteredConsumers {
+			if c != tc.expected[i] {
+				t.Errorf("Consumers do not match. Expected: [%s]\nActual: [%s]", tc.expected, filteredConsumers)
 			}
 		}
 	}

--- a/healthcheck_test.go
+++ b/healthcheck_test.go
@@ -344,7 +344,7 @@ func TestFilterOutNonRelatedKafkaBridges(t *testing.T) {
 		},
 		{
 			whitelistedEnvs:[]string{"prod-env", "pub-prod-env"},
-			consumers: []string{"console-consumer", "praod-env-kafka-bridge", "lower-env-kafka-bridge", "pre-prod-env-kafka-bridge", "pub-prod-env-kafka-bridge"},
+			consumers: []string{"console-consumer", "prod-env-kafka-bridge", "lower-env-kafka-bridge", "pre-prod-env-kafka-bridge", "pub-prod-env-kafka-bridge"},
 			expected:[]string{"console-consumer", "prod-env-kafka-bridge", "pub-prod-env-kafka-bridge"},
 		},
 

--- a/healthcheck_test.go
+++ b/healthcheck_test.go
@@ -1,10 +1,10 @@
 package main
 
 import (
-	"github.com/golang/go/src/pkg/errors"
 	"strings"
 	"testing"
 	"io/ioutil"
+	"errors"
 )
 
 func TestConsumerStatus(t *testing.T) {
@@ -218,7 +218,7 @@ func TestConsumerStatus(t *testing.T) {
 		},
 	}
 	initLogs(ioutil.Discard, ioutil.Discard, ioutil.Discard)
-	h := newHealthcheck("", []string{"Concept"}, 30)
+	h := newHealthcheck("", []string{"Concept"},[]string{}, 30)
 	for _, tc := range testCases {
 		actualErr := h.checkConsumerGroupForLags(tc.body, "xp-notifications-push-2")
 		actualMsg := "<nil>"
@@ -289,7 +289,7 @@ func TestConsumerList(t *testing.T) {
 		},
 	}
 	initLogs(ioutil.Discard, ioutil.Discard, ioutil.Discard)
-	h := newHealthcheck("", []string{"Concept"}, 30)
+	h := newHealthcheck("", []string{"Concept"},[]string{}, 30)
 	for _, tc := range testCases {
 		consumers, actualErr := h.parseConsumerGroups(tc.body)
 		actualMsg := "<nil>"

--- a/healthcheck_test.go
+++ b/healthcheck_test.go
@@ -1,10 +1,10 @@
 package main
 
 import (
+	"errors"
+	"io/ioutil"
 	"strings"
 	"testing"
-	"io/ioutil"
-	"errors"
 )
 
 func TestConsumerStatus(t *testing.T) {
@@ -218,7 +218,7 @@ func TestConsumerStatus(t *testing.T) {
 		},
 	}
 	initLogs(ioutil.Discard, ioutil.Discard, ioutil.Discard)
-	h := newHealthcheck("", []string{"Concept"},[]string{}, 30)
+	h := newHealthcheck("", []string{"Concept"}, []string{}, 30)
 	for _, tc := range testCases {
 		actualErr := h.checkConsumerGroupForLags(tc.body, "xp-notifications-push-2")
 		actualMsg := "<nil>"
@@ -289,7 +289,7 @@ func TestConsumerList(t *testing.T) {
 		},
 	}
 	initLogs(ioutil.Discard, ioutil.Discard, ioutil.Discard)
-	h := newHealthcheck("", []string{"Concept"},[]string{}, 30)
+	h := newHealthcheck("", []string{"Concept"}, []string{}, 30)
 	for _, tc := range testCases {
 		consumers, actualErr := h.parseConsumerGroups(tc.body)
 		actualMsg := "<nil>"

--- a/main.go
+++ b/main.go
@@ -44,7 +44,7 @@ func main() {
 
 	app.Action = func() {
 		initLogs(os.Stdout, os.Stdout, os.Stderr)
-		healthCheck := newHealthcheck(*hostMachine, *whitelistedTopics,*whitelistedEnvironments, *lagTolerance)
+		healthCheck := newHealthcheck(*hostMachine, *whitelistedTopics, *whitelistedEnvironments, *lagTolerance)
 		router := mux.NewRouter()
 		router.HandleFunc("/__health", healthCheck.checkHealth)
 		router.HandleFunc("/__gtg", healthCheck.gtg)

--- a/main.go
+++ b/main.go
@@ -29,6 +29,12 @@ func main() {
 		Desc:   "Comma-separated list of kafka topics that we do not need to check for lags. (e.g. Concept,AnotherQ)",
 		EnvVar: "WHITELISTED_TOPICS",
 	})
+	whitelistedEnvironments := app.Strings(cli.StringsOpt{
+		Name:   "whitelisted-environments",
+		Value:  []string{},
+		Desc:   "Comma-separated list of environments that contain kafka bridges that we need to check for lags. (e.g. prod-uk, prod-us)",
+		EnvVar: "WHITELISTED_ENVS",
+	})
 	lagTolerance := app.Int(cli.IntOpt{
 		Name:   "lag-tolerance",
 		Value:  0,
@@ -38,7 +44,7 @@ func main() {
 
 	app.Action = func() {
 		initLogs(os.Stdout, os.Stdout, os.Stderr)
-		healthCheck := newHealthcheck(*hostMachine, *whitelistedTopics, *lagTolerance)
+		healthCheck := newHealthcheck(*hostMachine, *whitelistedTopics,*whitelistedEnvironments, *lagTolerance)
 		router := mux.NewRouter()
 		router.HandleFunc("/__health", healthCheck.checkHealth)
 		router.HandleFunc("/__gtg", healthCheck.gtg)

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1,0 +1,41 @@
+{
+	"comment": "",
+	"ignore": "test",
+	"package": [
+		{
+			"checksumSHA1": "bVrDZENiBMj1q+q+Aa2QoMuwaWk=",
+			"path": "github.com/Financial-Times/go-fthealth",
+			"revision": "f9074331b3ab48bca0e6d0afc211a673d88ac925",
+			"revisionTime": "2016-06-16T09:04:59Z",
+			"version": "0.1.0",
+			"versionExact": "0.1.0"
+		},
+		{
+			"checksumSHA1": "g/V4qrXjUGG9B+e3hB+4NAYJ5Gs=",
+			"path": "github.com/gorilla/context",
+			"revision": "08b5f424b9271eedf6f9f0ce86cb9396ed337a42",
+			"revisionTime": "2016-08-17T18:46:32Z"
+		},
+		{
+			"checksumSHA1": "F5dR3/i70EhSIMZfeIV+H8/PtvM=",
+			"path": "github.com/gorilla/mux",
+			"revision": "392c28fe23e1c45ddba891b0320b3b5df220beea",
+			"revisionTime": "2017-01-18T13:43:44Z",
+			"version": "v1.3.0",
+			"versionExact": "v1.3.0"
+		},
+		{
+			"checksumSHA1": "pYoO37aSFZl2uJAXpePBDnGItZc=",
+			"path": "github.com/jawher/mow.cli",
+			"revision": "d3ffbc2f98b83e09dc8efd55ecec75eb5fd656ec",
+			"revisionTime": "2017-02-20T22:51:54Z"
+		},
+		{
+			"checksumSHA1": "GnYsUxBxUHGDBIaCeQbMdYUCzkA=",
+			"path": "github.com/jmoiron/jsonq",
+			"revision": "e874b168d07ecc7808bc950a17998a8aa3141d82",
+			"revisionTime": "2015-05-11T02:39:44Z"
+		}
+	],
+	"rootPath": "github.com/Financial-Times/kafka-lagcheck"
+}


### PR DESCRIPTION
This is meant to suppress warnings from pub-prod kafka-lagcheck caused by consumers (kafka-bridges) from lower envs.