### PR TITLE
Bugfix/log lagging consumers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ kafka-lagcheck
 kafka-lagcheck.exe
 *.iml
 vendor/*/
+/.project

--- a/circle.yml
+++ b/circle.yml
@@ -8,7 +8,7 @@ machine:
 checkout:
   post:
     - mkdir -p "${PROJECT_PARENT_PATH}"
-    - rsync -avC "${HOME}/${CIRCLE_PROJECT_REPONAME}/" "${PROJECT_PATH}"
+    - ln -sf "${HOME}/${CIRCLE_PROJECT_REPONAME}/" "${PROJECT_PATH}"
 
 dependencies:
   pre:

--- a/healthcheck_test.go
+++ b/healthcheck_test.go
@@ -1,10 +1,19 @@
 package main
 
 import (
+	"bytes"
 	"errors"
+	"fmt"
 	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
 	"strings"
+	"time"
+
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/jarcoal/httpmock.v1"
 )
 
 func TestConsumerStatus(t *testing.T) {
@@ -333,21 +342,20 @@ func TestFilterOutNonRelatedKafkaBridges(t *testing.T) {
 		expected        []string
 	}{
 		{
-			whitelistedEnvs:[]string{},
-			consumers: []string{"console-consumer", "prod-env-kafka-bridge", "lower-env-kafka-bridge"},
-			expected:[]string{"console-consumer", "prod-env-kafka-bridge", "lower-env-kafka-bridge"},
+			whitelistedEnvs: []string{},
+			consumers:       []string{"console-consumer", "prod-env-kafka-bridge", "lower-env-kafka-bridge"},
+			expected:        []string{"console-consumer", "prod-env-kafka-bridge", "lower-env-kafka-bridge"},
 		},
 		{
-			whitelistedEnvs:[]string{"prod-env"},
-			consumers: []string{"console-consumer", "prod-env-kafka-bridge", "lower-env-kafka-bridge"},
-			expected:[]string{"console-consumer", "prod-env-kafka-bridge"},
+			whitelistedEnvs: []string{"prod-env"},
+			consumers:       []string{"console-consumer", "prod-env-kafka-bridge", "lower-env-kafka-bridge"},
+			expected:        []string{"console-consumer", "prod-env-kafka-bridge"},
 		},
 		{
-			whitelistedEnvs:[]string{"prod-env", "pub-prod-env"},
-			consumers: []string{"console-consumer", "prod-env-kafka-bridge", "lower-env-kafka-bridge", "pre-prod-env-kafka-bridge", "pub-prod-env-kafka-bridge"},
-			expected:[]string{"console-consumer", "prod-env-kafka-bridge", "pub-prod-env-kafka-bridge"},
+			whitelistedEnvs: []string{"prod-env", "pub-prod-env"},
+			consumers:       []string{"console-consumer", "prod-env-kafka-bridge", "lower-env-kafka-bridge", "pre-prod-env-kafka-bridge", "pub-prod-env-kafka-bridge"},
+			expected:        []string{"console-consumer", "prod-env-kafka-bridge", "pub-prod-env-kafka-bridge"},
 		},
-
 	}
 
 	for _, tc := range testCases {
@@ -359,4 +367,192 @@ func TestFilterOutNonRelatedKafkaBridges(t *testing.T) {
 			}
 		}
 	}
+}
+
+func TestGTG(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	burrowUrl := "http://burrow.example.com"
+
+	consumers := map[string]interface{}{
+		"error":     false,
+		"message":   "consumer list returned",
+		"consumers": []string{"consumer1", "consumer2"},
+	}
+	consumersResponse, _ := httpmock.NewJsonResponder(200, consumers)
+	httpmock.RegisterResponder("GET", burrowUrl+"/v2/kafka/local/consumer/", consumersResponse)
+
+	consumerStatus := []map[string]interface{}{
+		map[string]interface{}{
+			"error":   false,
+			"message": "consumer group status returned",
+			"status": map[string]interface{}{
+				"status":   "OK",
+				"complete": true,
+				"partitions": []map[string]interface{}{
+					map[string]interface{}{"topic": "TestTopic"},
+				},
+				"partition_count": 1,
+				"maxlag":          nil,
+				"totallag":        0,
+			},
+		},
+		map[string]interface{}{
+			"error":   false,
+			"message": "consumer group status returned",
+			"status": map[string]interface{}{
+				"status":   "OK",
+				"complete": true,
+				"partitions": []map[string]interface{}{
+					map[string]interface{}{"topic": "TestTopic"},
+				},
+				"partition_count": 1,
+				"maxlag":          nil,
+				"totallag":        0,
+			},
+		},
+	}
+	for i, status := range consumerStatus {
+		statusResponse, _ := httpmock.NewJsonResponder(200, status)
+		httpmock.RegisterResponder("GET", fmt.Sprintf("%s/v2/kafka/local/consumer/consumer%d/status", burrowUrl, i+1), statusResponse)
+	}
+
+	h := newHealthcheck(burrowUrl, []string{}, []string{}, 0)
+
+	req, _ := http.NewRequest("GET", "http://localhost/__gtg", nil)
+	w := httptest.NewRecorder()
+	h.gtg(w, req)
+
+	actual := *w.Result()
+	assert.Equal(t, actual.StatusCode, http.StatusOK, "GTG HTTP status")
+}
+
+func TestGTGLaggingBeyondLimit(t *testing.T) {
+	buf := &bytes.Buffer{}
+	initLogs(buf, buf, buf)
+
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	burrowUrl := "http://burrow.example.com"
+
+	consumers := map[string]interface{}{
+		"error":     false,
+		"message":   "consumer list returned",
+		"consumers": []string{"consumer1", "consumer2"},
+	}
+	consumersResponse, _ := httpmock.NewJsonResponder(200, consumers)
+	httpmock.RegisterResponder("GET", burrowUrl+"/v2/kafka/local/consumer/", consumersResponse)
+
+	consumerStatus := []map[string]interface{}{
+		map[string]interface{}{
+			"error":   false,
+			"message": "consumer group status returned",
+			"status": map[string]interface{}{
+				"status":   "OK",
+				"complete": true,
+				"partitions": []map[string]interface{}{
+					map[string]interface{}{"topic": "TestTopic"},
+				},
+				"partition_count": 1,
+				"maxlag":          nil,
+				"totallag":        10,
+			},
+		},
+		map[string]interface{}{
+			"error":   false,
+			"message": "consumer group status returned",
+			"status": map[string]interface{}{
+				"status":   "OK",
+				"complete": true,
+				"partitions": []map[string]interface{}{
+					map[string]interface{}{"topic": "TestTopic"},
+				},
+				"partition_count": 1,
+				"maxlag":          nil,
+				"totallag":        6,
+			},
+		},
+	}
+	for i, status := range consumerStatus {
+		statusResponse, _ := httpmock.NewJsonResponder(200, status)
+		httpmock.RegisterResponder("GET", fmt.Sprintf("%s/v2/kafka/local/consumer/consumer%d/status", burrowUrl, i+1), statusResponse)
+	}
+
+	h := newHealthcheck(burrowUrl, []string{}, []string{}, 5)
+
+	req, _ := http.NewRequest("GET", "http://localhost/__gtg", nil)
+	w := httptest.NewRecorder()
+	h.gtg(w, req)
+	actual := *w.Result()
+	assert.Equal(t, actual.StatusCode, http.StatusServiceUnavailable, "GTG HTTP status")
+
+	// give a little time for logging goroutine to catch up
+	time.Sleep(100 * time.Millisecond)
+
+	logs := string(buf.Bytes())
+	for i, status := range consumerStatus {
+		expected := fmt.Sprintf(".*Lagging consumers:.+consumer%d consumer group is lagging behind with %d messages.*", i+1, status["status"].(map[string]interface{})["totallag"])
+		assert.Regexp(t, expected, logs, "lagging consumer log")
+	}
+}
+
+func TestGTGLaggingWithinLimit(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	burrowUrl := "http://burrow.example.com"
+
+	consumers := map[string]interface{}{
+		"error":     false,
+		"message":   "consumer list returned",
+		"consumers": []string{"consumer1", "consumer2"},
+	}
+	consumersResponse, _ := httpmock.NewJsonResponder(200, consumers)
+	httpmock.RegisterResponder("GET", burrowUrl+"/v2/kafka/local/consumer/", consumersResponse)
+
+	consumerStatus := []map[string]interface{}{
+		map[string]interface{}{
+			"error":   false,
+			"message": "consumer group status returned",
+			"status": map[string]interface{}{
+				"status":   "OK",
+				"complete": true,
+				"partitions": []map[string]interface{}{
+					map[string]interface{}{"topic": "TestTopic"},
+				},
+				"partition_count": 1,
+				"maxlag":          nil,
+				"totallag":        10,
+			},
+		},
+		map[string]interface{}{
+			"error":   false,
+			"message": "consumer group status returned",
+			"status": map[string]interface{}{
+				"status":   "OK",
+				"complete": true,
+				"partitions": []map[string]interface{}{
+					map[string]interface{}{"topic": "TestTopic"},
+				},
+				"partition_count": 1,
+				"maxlag":          nil,
+				"totallag":        0,
+			},
+		},
+	}
+	for i, status := range consumerStatus {
+		statusResponse, _ := httpmock.NewJsonResponder(200, status)
+		httpmock.RegisterResponder("GET", fmt.Sprintf("%s/v2/kafka/local/consumer/consumer%d/status", burrowUrl, i+1), statusResponse)
+	}
+
+	h := newHealthcheck(burrowUrl, []string{}, []string{}, 10)
+
+	req, _ := http.NewRequest("GET", "http://localhost/__gtg", nil)
+	w := httptest.NewRecorder()
+	h.gtg(w, req)
+
+	actual := *w.Result()
+	assert.Equal(t, actual.StatusCode, http.StatusOK, "GTG HTTP status")
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3,12 +3,12 @@
 	"ignore": "test",
 	"package": [
 		{
-			"checksumSHA1": "jd4AfgUztNE40RJyJzz/ViDJKEc=",
-			"path": "github.com/Financial-Times/go-fthealth",
-			"revision": "f9074331b3ab48bca0e6d0afc211a673d88ac925",
-			"revisionTime": "2016-06-16T09:04:59Z",
-			"version": "0.1.0",
-			"versionExact": "0.1.0"
+			"checksumSHA1": "hA3MoSjATaM7AQknoqXcE5skk00=",
+			"path": "github.com/Financial-Times/go-fthealth/v1_1",
+			"revision": "e7ccca038327a0091303a52445ec1f0fb66cb97b",
+			"revisionTime": "2017-05-25T09:50:41Z",
+			"version": "0.3.0",
+			"versionExact": "0.3.0"
 		},
 		{
 			"checksumSHA1": "Lps/+JqMRVlrXgO/+cazYcfsglg=",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -11,6 +11,12 @@
 			"versionExact": "0.1.0"
 		},
 		{
+			"checksumSHA1": "Lps/+JqMRVlrXgO/+cazYcfsglg=",
+			"path": "github.com/davecgh/go-spew/spew",
+			"revision": "346938d642f2ec3594ed81d874461961cd0faa76",
+			"revisionTime": "2016-10-29T20:57:26Z"
+		},
+		{
 			"checksumSHA1": "IkPM2QLv9urri7S49wzroQx9oXA=",
 			"path": "github.com/gorilla/context",
 			"revision": "08b5f424b9271eedf6f9f0ce86cb9396ed337a42",
@@ -35,6 +41,20 @@
 			"path": "github.com/jmoiron/jsonq",
 			"revision": "e874b168d07ecc7808bc950a17998a8aa3141d82",
 			"revisionTime": "2015-05-11T02:39:44Z"
+		},
+		{
+			"checksumSHA1": "R3yk3OJzuq4MVfVGX5AhkkYv1ko=",
+			"path": "github.com/pmezard/go-difflib/difflib",
+			"revision": "792786c7400a136282c1664665ae0a8db921c6c2",
+			"revisionTime": "2016-01-10T10:55:54Z"
+		},
+		{
+			"checksumSHA1": "3fuOD4+Q7k/yYdaklodK+6njEm0=",
+			"path": "github.com/stretchr/testify/assert",
+			"revision": "69483b4bd14f5845b5a1e55bca19e954e827f1d0",
+			"revisionTime": "2016-09-25T01:54:16Z",
+			"version": "v1.1.4",
+			"versionExact": "v1.1.4"
 		},
 		{
 			"checksumSHA1": "eMixaPTahRdSz6l2yOKtUOaAcJM=",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3,7 +3,7 @@
 	"ignore": "test",
 	"package": [
 		{
-			"checksumSHA1": "bVrDZENiBMj1q+q+Aa2QoMuwaWk=",
+			"checksumSHA1": "jd4AfgUztNE40RJyJzz/ViDJKEc=",
 			"path": "github.com/Financial-Times/go-fthealth",
 			"revision": "f9074331b3ab48bca0e6d0afc211a673d88ac925",
 			"revisionTime": "2016-06-16T09:04:59Z",
@@ -11,13 +11,13 @@
 			"versionExact": "0.1.0"
 		},
 		{
-			"checksumSHA1": "g/V4qrXjUGG9B+e3hB+4NAYJ5Gs=",
+			"checksumSHA1": "IkPM2QLv9urri7S49wzroQx9oXA=",
 			"path": "github.com/gorilla/context",
 			"revision": "08b5f424b9271eedf6f9f0ce86cb9396ed337a42",
 			"revisionTime": "2016-08-17T18:46:32Z"
 		},
 		{
-			"checksumSHA1": "F5dR3/i70EhSIMZfeIV+H8/PtvM=",
+			"checksumSHA1": "pLA4j6v1jGIQExmYHf40KjSfkM4=",
 			"path": "github.com/gorilla/mux",
 			"revision": "392c28fe23e1c45ddba891b0320b3b5df220beea",
 			"revisionTime": "2017-01-18T13:43:44Z",
@@ -25,16 +25,22 @@
 			"versionExact": "v1.3.0"
 		},
 		{
-			"checksumSHA1": "pYoO37aSFZl2uJAXpePBDnGItZc=",
+			"checksumSHA1": "rW0QSLVB0eUCzMdIL7yigeLBQ54=",
 			"path": "github.com/jawher/mow.cli",
 			"revision": "d3ffbc2f98b83e09dc8efd55ecec75eb5fd656ec",
 			"revisionTime": "2017-02-20T22:51:54Z"
 		},
 		{
-			"checksumSHA1": "GnYsUxBxUHGDBIaCeQbMdYUCzkA=",
+			"checksumSHA1": "muWASuZ+3Z3aUpkGEHQhwYqZ3n4=",
 			"path": "github.com/jmoiron/jsonq",
 			"revision": "e874b168d07ecc7808bc950a17998a8aa3141d82",
 			"revisionTime": "2015-05-11T02:39:44Z"
+		},
+		{
+			"checksumSHA1": "eMixaPTahRdSz6l2yOKtUOaAcJM=",
+			"path": "gopkg.in/jarcoal/httpmock.v1",
+			"revision": "cf52904a3cf0f78f199ecade6a6df8e245d5b25a",
+			"revisionTime": "2017-04-12T08:57:02Z"
 		}
 	],
 	"rootPath": "github.com/Financial-Times/kafka-lagcheck"


### PR DESCRIPTION
On discovering a lagging consumer, return 503 immediately, but continue to check all consumers, and then log a list of lagging consumers to assist in post-hoc diagnosis.