### PR TITLE
Increase lag threshold in K8S

### DIFF
--- a/helm/kafka-lagcheck/app-configs/kafka-lagcheck_delivery.yaml
+++ b/helm/kafka-lagcheck/app-configs/kafka-lagcheck_delivery.yaml
@@ -5,5 +5,5 @@ service:
 env:
   WHITELISTED_TOPICS: "Concept"
   BURROW_URL: "http://burrow:8080"
-  ERR_LAG_TOLERANCE: 20
+  ERR_LAG_TOLERANCE: 35
   MAX_LAG_TOLERANCE: 1000

--- a/helm/kafka-lagcheck/app-configs/kafka-lagcheck_publishing.yaml
+++ b/helm/kafka-lagcheck/app-configs/kafka-lagcheck_publishing.yaml
@@ -5,5 +5,5 @@ service:
 env:
   WHITELISTED_TOPICS: "Concept"
   BURROW_URL: "http://burrow:8080"
-  ERR_LAG_TOLERANCE: 20
+  ERR_LAG_TOLERANCE: 35
   MAX_LAG_TOLERANCE: 1000

--- a/helm/kafka-lagcheck/templates/deployment.yaml
+++ b/helm/kafka-lagcheck/templates/deployment.yaml
@@ -34,7 +34,7 @@ spec:
           value: {{ .Values.env.BURROW_URL }}
         - name: MAX_LAG_TOLERANCE
           value: "{{ .Values.env.MAX_LAG_TOLERANCE }}"
-        - name: MAX_LAG_TOLERANCE
+        - name: ERR_LAG_TOLERANCE
           value: "{{ .Values.env.ERR_LAG_TOLERANCE }}"
         ports:
         - containerPort: 8080


### PR DESCRIPTION
- we've been seeing lots of kafka lagcheck alerts for lags which hover around 20 to 30 so we increased the threshold to accommodate this 